### PR TITLE
Update README.md. FIX Typo - Rename ocid to oidc

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ android.defaultConfig.manifestPlaceholders = [
 ]
 ```
 
-4. Inside your Android application `res/raw` floder create `ocid.json` file with the following
+4. Inside your Android application `res/raw` floder create `oidc.json` file with the following
    configuration. `issueUri` and `registrationUri` are optional in the current version.
 
 ```json


### PR DESCRIPTION
FIX: Typo - Rename ocid to oidc